### PR TITLE
fix(winline): use api.nvim_strwidth to calculate lengths

### DIFF
--- a/lua/incline/winline.lua
+++ b/lua/incline/winline.lua
@@ -4,6 +4,10 @@ local a = vim.api
 
 local Winline = {}
 
+local function strlen(str)
+  return a.nvim_strwidth(str)
+end
+
 function Winline:is_alive()
   return a.nvim_win_is_valid(self.target_win)
 end
@@ -119,12 +123,12 @@ function Winline:render(opts)
     content = content .. pad
   end
 
-  if self.content and #content ~= #self.content then
+  if self.content and strlen(content) ~= strlen(self.content) then
     opts.refresh = true
   end
 
   self.content = content
-  self:win { refresh = opts.refresh, content_len = #self.content }
+  self:win { refresh = opts.refresh, content_len = strlen(self.content) }
   a.nvim_buf_set_lines(self:buf(), 0, -1, false, { self.content })
 end
 


### PR DESCRIPTION
Whilst messing about with a more jazzy winline 👇🏿 I noticed that it was rendering with a much longer window than necessary because I was using icons. Applying this fix gives the correct length for the string passed in.
<img width="565" alt="Screen Shot 2022-04-27 at 17 37 59" src="https://user-images.githubusercontent.com/22454918/165573484-426176c0-2500-49ff-8aac-9bc89556f99b.png">
This image is of the corrected string.

This is because Lua's # or len function count the number of
bytes rather than the cells that a string will occupy. This means that
it will often over count the size of a string for usecases like TUI
elements in nvim

The function to create this is
```lua
          render = function(props)
            ---@diagnostic disable-next-line: redefined-local
            local fmt, icons = string.format, as.style.icons.misc
            local bufname = vim.api.nvim_buf_get_name(props.buf)
            if bufname == '' then
              return '[No name]'
            end
            local parts = vim.split(vim.fn.fnamemodify(bufname, ':.'), '/')
            local icon, _ = require('nvim-web-devicons').get_icon(bufname, nil, { default = true })
            parts[#parts] = fmt('%s %s', icon, parts[#parts])
            return table.concat(parts, fmt(' %s ', icons.chevron_right))
          end
```