### PR TITLE
debounce initial refresh for faster setup

### DIFF
--- a/lua/incline/manager.lua
+++ b/lua/incline/manager.lua
@@ -94,7 +94,7 @@ end
 M.setup = function()
   if state.initialized then
     M.update.threshold = config.debounce_threshold
-    M.update:immediate { refresh = true }
+    M.update { refresh = true }
     return
   end
   local events = {
@@ -120,7 +120,7 @@ M.setup = function()
       M.update()
     end,
   })
-  M.update:immediate { refresh = true }
+  M.update { refresh = true }
   state.initialized = true
 end
 


### PR DESCRIPTION
first of all, thank you for this plugin! 

Using it I found that it slowed down my initial nvim startup/setup time by ~14ms, which seemed odd for a plugin like this. 
This change defers the initial draw of the `Winline` and brought the setup-time down to 1-2ms. 

Looking through the history of these lines (specifically 752a84b33d535eaa0551dbb5a20244495f12e361 and 48ceec2df7122545c6c657497387def728985d32 ) I couldn't see a reason why deferring this should be a problem. 

I'm happy to apply any needed changes. 
 