### PR TITLE
Fix duplicate help tag

### DIFF
--- a/doc/incline.txt
+++ b/doc/incline.txt
@@ -694,7 +694,7 @@ replace~
 >
     require'incline.config'.replace
 <
-                                                     *incline-transform-replace*
+                                                     *incline-transform-extend*
 extend~
   Extends the default value of the option. Only valid for options with default
   values that are list-like or dict-like tables.


### PR DESCRIPTION
This is a fix for a duplicate help tag error.

Fix of the following
```
:helptags {this plugin directory}
E154: Duplicate tag "incline-transform-replace" in file ...
```