### PR TITLE
Fix missing updates on terminal resize

### DIFF
--- a/lua/incline/manager.lua
+++ b/lua/incline/manager.lua
@@ -112,6 +112,7 @@ M.setup = function()
     'WinEnter',
     'WinLeave',
     'WinScrolled', -- WinScrolled is used to detect window resizes
+    'VimResized', -- VimResized detects changes in the overall terminal size
     'TabEnter',
     'TabNewEntered',
     'BufWinEnter',


### PR DESCRIPTION
I found a case where the positions weren't updating, specifically when splits were rebalanced by an autocmd on `VimResized`. This change seems to cover that gap.

I tried replacing `WinScrolled` but it seems to pick up changes to manually resized vertical splits that `VimResized` misses.