### PR TITLE
fix: overlap the separator line in bottom mode

### DIFF
--- a/lua/incline/winline.lua
+++ b/lua/incline/winline.lua
@@ -73,7 +73,10 @@ function Winline:get_win_geom_row()
     end
     return cw.margin.vertical.top
   elseif placement.vertical == 'bottom' then
-    return a.nvim_win_get_height(self.target_win) - cw.margin.vertical.bottom
+    if cw.margin.vertical.bottom == 0 and (vim.o.laststatus ~= 3 or a.nvim_win_get_position(self.target_win)[1] + a.nvim_win_get_height(self.target_win) >= vim.o.lines - vim.o.cmdheight - 1) then
+      return a.nvim_win_get_height(self.target_win) - cw.margin.vertical.bottom
+    end
+    return a.nvim_win_get_height(self.target_win) - cw.margin.vertical.bottom + 1
   end
   assert(false, 'invalid value for placement.vertical: ' .. tostring(placement.vertical))
 end


### PR DESCRIPTION
Hi,

I wanted what was requested in #27 and realized it was not a complicated fix. Here it is :).

When window.placement.vertical == "bottom", this fix put the label on top of the split separator line.
Of course it behave like before the fix if laststatus is not 3 or if the windows is at the bottom of the screen.
I made sure that works with any value of cmdheigh too (notably because I use cmdheight=0)

Looks pretty cool in my opinion :+1: 
![screenshot](https://github.com/b0o/incline.nvim/assets/24568527/d1387dd2-071f-4f9b-ad7b-b2ab417d1e98)

I think this is a reasonable enough behavior (and symmetric to the top case) that it doesn't need to be configurable, but I can add some sort of switch if you prefer.