### PR TITLE
fix: do not create a border with vim.o.winborder

### DIFF
--- a/lua/incline/winline.lua
+++ b/lua/incline/winline.lua
@@ -178,6 +178,7 @@ function Winline:get_win_config()
     col = geom.col,
     relative = 'editor',
     style = 'minimal',
+    border = 'none',
     focusable = false,
   }
 end


### PR DESCRIPTION
Hi, `vim.o.winborder` is a new option to set a border for every floating window that doesn't have a border set up. So using `vim.o.winborder = "rounded"` creates a border around incline.nvim which is not what we want, so i set `border = "none"` for the floating window

before the fix:
![20250323_14h29m36s_grim](https://github.com/user-attachments/assets/59b5d7b2-f4de-4d87-9046-e2fd463cc8bc)

after the fix:
![20250323_14h29m58s_grim](https://github.com/user-attachments/assets/da986eb4-3a90-46fb-b605-bc9b45393d75)
