### PR TITLE
Fix incline floating windows being treated as regular buffers

### DIFF
--- a/lua/incline/winline.lua
+++ b/lua/incline/winline.lua
@@ -54,7 +54,13 @@ function Winline:buf()
     return self._buf
   end
   self._buf = a.nvim_create_buf(false, true)
+
   a.nvim_buf_set_option(self._buf, 'filetype', 'incline')
+  a.nvim_buf_set_option(self._buf, 'buftype', 'nofile')
+  a.nvim_buf_set_option(self._buf, 'bufhidden', 'wipe')
+  a.nvim_buf_set_option(self._buf, 'buflisted', false)
+  a.nvim_buf_set_option(self._buf, 'swapfile', false)
+
   return self._buf
 end
 


### PR DESCRIPTION
## Issue
I have a (bad?) habit of occasionally doing `:%bd` when my workspace gets cluttered and I want to clean up and reset. When I do this, incline's floating windows get treated as a regular buffer with unsaved changes so I can't quit out of neovim with `:qa` without forcing it `:qa!`

## Reproduce
To reproduce, open any file, run `:%bd` then `:qa`.

## Fix
To fix it, I set a few more buffer options to have Neovim not treat it as a regular buffer and it's been working as intended. Tested on v0.11.1.

---
Thanks for creating Incline! I've been using it for a long time now and really enjoy how it looks and works. 

Cheers